### PR TITLE
render_notifications is allways showing "<b>No notifications yet.</b>"

### DIFF
--- a/notify/templatetags/notification_tags.py
+++ b/notify/templatetags/notification_tags.py
@@ -49,7 +49,7 @@ class RenderNotificationsNode(template.Node):
             extra = nf.as_json() if self.target == 'box' else {}
             html = render_notification(nf, render_target=self.target, **extra)
             html_chunks.append(html)
-        else:
+        if not html_chunks:
             html_chunks.append(_("<b>No notifications yet.</b>"))
         html_string = '\n'.join(html_chunks)
         return html_string

--- a/notify/tests/tests.py
+++ b/notify/tests/tests.py
@@ -620,7 +620,7 @@ class NotificationTemplateTagTest(TestCase):
         self.assertIn('followed you', rendered)
 
     def test_render_template_tag_with_empty_notifications(self):
-        nf_list = Notification.objects.filter(recipient=self.user).active()
+        nf_list = Notification.objects.filter(recipient=self.user).none()
         rendered = self.RENDER_TEMPLATE.render(
             Context({'notifications': nf_list}))
         self.assertIn('No notifications yet', rendered)


### PR DESCRIPTION
The bug was in this code block:

``` python
        for nf in notifications:
            extra = nf.as_json() if self.target == 'box' else {}
            html = render_notification(nf, render_target=self.target, **extra)
            html_chunks.append(html)
        else:
            html_chunks.append(_("<b>No notifications yet.</b>"))
```

An `else` into a for loop is not executed only if a `break` statement is executed inside that loop. See [this doc for deep explanation](http://python-notes.curiousefficiency.org/en/latest/python_concepts/break_else.html).

I changed to a normal `if`.