### PR TITLE
Allow custom render targets

### DIFF
--- a/notify/templatetags/notification_tags.py
+++ b/notify/templatetags/notification_tags.py
@@ -34,7 +34,7 @@ class RenderNotificationsNode(template.Node):
                 _("{tag} takes 2 or 3 arguments, {len} given.").format(
                     tag=tokens[0], len=len(tokens)))
 
-    def __init__(self, obj, target='page'):
+    def __init__(self, obj, target=''):
         self.obj = obj
         self.target = target
 

--- a/notify/utils.py
+++ b/notify/utils.py
@@ -1,14 +1,14 @@
 from django.template.loader import render_to_string
 
 
-def render_notification(notification, render_target='page', **extra):
+def render_notification(notification, render_target='', **extra):
     template_name = notification.nf_type
     template_dir = 'notifications/includes/'
 
     nf_ctx = {'notification': notification}
     nf_ctx.update(extra)
 
-    suffix = '_box' if render_target == 'box' else ''
+    suffix = '_{}'.format(render_target) if render_target and render_target != 'page' else ''
     templates = [
         "{0}{1}{2}.html".format(template_dir, template_name, suffix),
         "{0}{1}.html".format(template_dir, template_name),
@@ -16,6 +16,7 @@ def render_notification(notification, render_target='page', **extra):
     ]
 
     return render_to_string(templates, nf_ctx)
+
 
 def prefetch_relations(weak_queryset):
     """

--- a/notify/views.py
+++ b/notify/views.py
@@ -226,6 +226,7 @@ def notification_update(request):
     :return: Notification updates (if any) in JSON format.
     """
     flag = request.GET.get('flag', None)
+    target = request.GET.get('target', 'box')
     last_notification = int(flag) if flag.isdigit() else None
 
     if last_notification:
@@ -240,7 +241,7 @@ def notification_update(request):
             notification = nf.as_json()
             notification_list.append(notification)
             notification['html'] = render_notification(
-                nf, render_target='box', **notification)
+                nf, render_target=target, **notification)
 
         ctx = {
             "retrieved": len(new_notifications),


### PR DESCRIPTION
Allow custom render targets of notifications.

I'm pushing notifications to mobile, with required another set of templates. But the current underlying components and views only allow `box` or `page`. This commit enables custom render targets using a get param `target`:

Eg.: 

    GET /api/update/?flag=1&target=api

The default behaviour remains unchanged, using `page` if target is not specified.