### PR TITLE
Fix ascii decode error when model representation contains unicode data

### DIFF
--- a/notify/models.py
+++ b/notify/models.py
@@ -8,6 +8,7 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.utils.html import escape
 from django.utils.timesince import timesince
 from django.utils.translation import ugettext_lazy as _
+from django.utils.encoding import force_text
 
 from .utils import prefetch_relations
 
@@ -365,14 +366,14 @@ class Notification(models.Model):
     def do_escape(obj):
         """
         Method to HTML escape an object or set it to None conditionally.
-        performs ``str()`` on the argument so that a foreignkey gets
+        performs ``force_text()`` on the argument so that a foreignkey gets
         serialized? and spit out the ``__str__`` output instead of an Object.
 
         :param obj: Object to escape.
 
         :return: HTML escaped and JSON-friendly data.
         """
-        return escape(str(obj)) if obj else None
+        return escape(force_text(obj)) if obj else None
 
     def as_json(self):
         """


### PR DESCRIPTION
When escaping objects to text, we are using `str`, but if the obj representation contains invalid ascii caracters, the code breaks:

    UnicodeEncodeError: 'ascii' codec can't encode character u'\xea' in position 12: ordinal not in range(128)

This pull request replaces `str` with the Django's `force_text` that properly handles unicode.