### PR TITLE
Target precedence on render_notification

### DIFF
--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -61,8 +61,9 @@ For full page notifications, we'll try to find a template in the following order
 For live ajax notifications, we'll try to find a template in the following order::
 
     followed_user_box.html
-    followed_user.html
     default_box.html
+    followed_user.html
+    defaul.html
 
 
 **Contents of `notifications/includes/followed_user.html`**::

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -56,14 +56,14 @@ Put those files in ``notifications/includes/`` directory of your template direct
 For full page notifications, we'll try to find a template in the following order::
 
     followed_user.html
-    defaul.html
+    default.html
 
 For live ajax notifications, we'll try to find a template in the following order::
 
     followed_user_box.html
     default_box.html
     followed_user.html
-    defaul.html
+    default.html
 
 
 **Contents of `notifications/includes/followed_user.html`**::

--- a/notify/utils.py
+++ b/notify/utils.py
@@ -11,8 +11,9 @@ def render_notification(notification, render_target='', **extra):
     suffix = '_{}'.format(render_target) if render_target and render_target != 'page' else ''
     templates = [
         "{0}{1}{2}.html".format(template_dir, template_name, suffix),
-        "{0}{1}.html".format(template_dir, template_name),
         "{0}default{1}.html".format(template_dir, suffix),
+        "{0}{1}.html".format(template_dir, template_name),
+        "{0}default.html".format(template_dir),
     ]
 
     return render_to_string(templates, nf_ctx)


### PR DESCRIPTION
If a suffix is given, then the templates of the suffix has higher precedence over the default (empty suffix).

In the case of a custom target like `api`, and a `nf_type='badge_awarded'`.

The default template of this target should have higher precedence over the templates of the default (page=empty target), in order to allow a default target message.

To an `api` target, no HTML tags are required, only the text, then the `default_api.html` could be something like this:

```{% if actor %}{{ actor }} {% endif %}{{ verb }}{% if target %}: {% block target %}{{ target }}{% endblock target %}{% endif %}```


Best regards,