### PR TITLE
Default flag to empty string in notification_update view

### DIFF
--- a/notify/tests/tests.py
+++ b/notify/tests/tests.py
@@ -508,6 +508,16 @@ class NotificationViewTest(TestCase):
         # request is still successful
         self.assertTrue(resp2['success'])
 
+    def test_update_view_without_flag(self):
+        url = reverse('notifications:update')
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        resp = json.loads(response.content.decode('utf-8'))
+
+        self.assertFalse(resp['success'])
+
     def test_read_and_redirect(self):
         """
         when users visits the view, they are redirected

--- a/notify/views.py
+++ b/notify/views.py
@@ -229,7 +229,7 @@ def notification_update(request):
 
     :return: Notification updates (if any) in JSON format.
     """
-    flag = request.GET.get('flag', None)
+    flag = request.GET.get('flag', '')
     target = request.GET.get('target', 'box')
     last_notification = int(flag) if flag.isdigit() else None
 


### PR DESCRIPTION
Hi & thanks for this cool library,
I spot a tiny issue while calling GET on `/notify/api/update/` without `flag` attribute. This should fix it.
Cheers :ok_hand: 

P.S. This is my first open source contrib ever :innocent: