### PR TITLE
Migrate to six

### DIFF
--- a/notify/models.py
+++ b/notify/models.py
@@ -4,7 +4,7 @@ from django.db import models
 from django.conf import settings
 from django.db.models import QuerySet
 from jsonfield.fields import JSONField
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 from django.utils.html import escape
 from django.utils.timesince import timesince
 from django.utils.translation import ugettext_lazy as _


### PR DESCRIPTION
django.utils.encoding.python_2_unicode_compatible was removed in Django 3.0. As the release documentation mentions.  
python_2_unicode_compatible has  moved to six.